### PR TITLE
fix:启动前同步数据库的尝试

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,5 @@ next-env.d.ts
 
 .env
 /.vscode
+# prisma
+/prisma/migrations

--- a/package.json
+++ b/package.json
@@ -3,8 +3,8 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
-    "dev": "prisma generate && next dev",
-    "build": "prisma generate && next build",
+    "dev": "prisma generate && node sync-database.js && next dev",
+    "build": "prisma generate && node sync-database.js && next build",
     "start": "next start",
     "lint": "next lint"
   },

--- a/sync-database.js
+++ b/sync-database.js
@@ -1,0 +1,41 @@
+const { exec } = require('child_process');
+
+// 检测数据库是否存在
+function checkDatabase() {
+    return new Promise((resolve, reject) => {
+        exec('npx prisma migrate status', (error, stdout, stderr) => {
+            if (error) {
+                reject(error);
+            } else {
+                resolve(stdout);
+            }
+        });
+    });
+}
+
+// 同步数据库
+function syncDatabase() {
+    return new Promise((resolve, reject) => {
+        exec('npx prisma migrate dev --name init', (error, stdout, stderr) => {
+            if (error) {
+                reject(error);
+            } else {
+                resolve(stdout);
+            }
+        });
+    });
+}
+
+// 主函数
+async function main() {
+    try {
+        await checkDatabase();
+        console.log('数据库已存在，无需同步。');
+    } catch (error) {
+        console.log('数据库不存在，正在同步...');
+        await syncDatabase();
+        console.log('数据库同步完成。');
+    }
+}
+
+main();


### PR DESCRIPTION
在程序dev和build前，会先检查数据库表是否存在，若不存在则会新建，已存在则会跳过，通过`sync-database.js`粗略实现，已在本地和Vercel完成测试，均可在第一次部署后正常使用注册